### PR TITLE
Fix for ie11

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "@gmod/bgzf-filehandle": "^1.2.1",
     "buffer-crc32": "^0.2.13",
     "es6-promisify": "^6.0.1",
-    "long": "^4.0.0"
+    "long": "^4.0.0",
+    "quick-lru": "^2.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "@gmod/bgzf-filehandle": "^1.2.1",
     "buffer-crc32": "^0.2.13",
     "long": "^4.0.0",
-    "lru-cache": "^4.1.3",
     "util.promisify": "^1.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
   "dependencies": {
     "@gmod/bgzf-filehandle": "^1.2.1",
     "buffer-crc32": "^0.2.13",
-    "long": "^4.0.0",
-    "util.promisify": "^1.0.0"
+    "es6-promisify": "^6.0.1",
+    "long": "^4.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/src/bamFile.js
+++ b/src/bamFile.js
@@ -1,5 +1,5 @@
 const { unzip } = require('@gmod/bgzf-filehandle')
-const LRU = require('lru-cache')
+const LRU = require('quick-lru')
 
 const BAI = require('./bai')
 const CSI = require('./csi')
@@ -53,8 +53,8 @@ class BamFile {
       this.index = new BAI({ filehandle: new LocalFile(`${bamPath}.bai`) })
     }
 
-    this.featureCache = LRU({
-      max: cacheSize !== undefined ? cacheSize : 20000,
+    this.featureCache = new LRU({
+      maxSize: cacheSize !== undefined ? cacheSize : 20000,
       length: featureArray => featureArray.length,
     })
 

--- a/src/localFile.js
+++ b/src/localFile.js
@@ -1,4 +1,4 @@
-const promisify = require('util.promisify')
+const {promisify} = require('es6-promisify')
 
 // don't load fs native module if running in webpacked code
 const fs = typeof __webpack_require__ !== 'function' ? require('fs') : null // eslint-disable-line camelcase

--- a/src/localFile.js
+++ b/src/localFile.js
@@ -1,4 +1,4 @@
-const {promisify} = require('es6-promisify')
+const { promisify } = require('es6-promisify')
 
 // don't load fs native module if running in webpacked code
 const fs = typeof __webpack_require__ !== 'function' ? require('fs') : null // eslint-disable-line camelcase

--- a/test/lib/io/bufferCache.js
+++ b/test/lib/io/bufferCache.js
@@ -1,11 +1,11 @@
-const LRU = require('lru-cache')
+const LRU = require('quick-lru')
 
 class BufferCache {
   constructor({ fetch, size = 10000000, chunkSize = 32768 }) {
     if (!fetch) throw new Error('fetch function required')
     this.fetch = fetch
     this.chunkSize = chunkSize
-    this.lruCache = LRU({ max: Math.floor(size / chunkSize) })
+    this.lruCache = new LRU({ maxSize: Math.floor(size / chunkSize) })
   }
   async get(outputBuffer, offset, length, position) {
     if (outputBuffer.length < offset + length)

--- a/test/lib/io/localFile.js
+++ b/test/lib/io/localFile.js
@@ -1,4 +1,4 @@
-const promisify = require('util.promisify')
+const {promisify} = require('es6-promisify')
 
 // don't load fs native module if running in webpacked code
 const fs = typeof __webpack_require__ !== 'function' ? require('fs') : null // eslint-disable-line camelcase

--- a/test/lib/io/localFile.js
+++ b/test/lib/io/localFile.js
@@ -1,4 +1,4 @@
-const {promisify} = require('es6-promisify')
+const { promisify } = require('es6-promisify')
 
 // don't load fs native module if running in webpacked code
 const fs = typeof __webpack_require__ !== 'function' ? require('fs') : null // eslint-disable-line camelcase

--- a/yarn.lock
+++ b/yarn.lock
@@ -3983,7 +3983,7 @@ lowercase-keys@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz#6f9e30b47084d971a7c820ff15a6c5167b74c26f"
 
-lru-cache@^4.0.1, lru-cache@^4.1.3:
+lru-cache@^4.0.1:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.3.tgz#a1175cf3496dfc8436c156c334b4955992bce69c"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -4888,6 +4888,11 @@ quick-lru@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-1.1.0.tgz#4360b17c61136ad38078397ff11416e186dcfbb8"
 
+quick-lru@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-2.0.0.tgz#32b017b28d1784631c8ab0a1ed2978e094dbe181"
+  integrity sha512-DqOtZziv7lDjEyuqyVQacRciAwMCEjTNrLYCHYEIIgjcE/tLEpBF82hiDIwCjRnEL9/hY2GJxA0T8ZvYvVVSSA==
+
 randomatic@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-3.0.0.tgz#d35490030eb4f7578de292ce6dfb04a91a128923"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2039,6 +2039,11 @@ es-to-primitive@^1.1.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.1"
 
+es6-promisify@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/es6-promisify/-/es6-promisify-6.0.1.tgz#6edaa45f3bd570ffe08febce66f7116be4b1cdb6"
+  integrity sha512-J3ZkwbEnnO+fGAKrjVpeUAnZshAdfZvbhQpqfIH9kSAspReRC4nJnu8ewm55b4y9ElyeuhCTzJD0XiH8Tsbhlw==
+
 escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"


### PR DESCRIPTION
This changes to use quick-lru which aids IE11 compatibility because lru-cache uses Object.defineProperty on length which seems un-babel-ifiable

The util.promisify also can end up doing Object.defineProperty on the length property too so es6-promisify is used