### PR TITLE
Add ability to read from server that is returning badly non-gzipped data

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,9 +41,11 @@
   "dependencies": {
     "@babel/runtime-corejs2": "^7.5.5",
     "@gmod/bgzf-filehandle": "^1.3.0",
+    "@types/buffer-crc32": "^0.2.0",
     "@types/long": "^4.0.0",
     "@types/node": "^12.7.8",
     "abortable-promise-cache": "^1.0.1",
+    "buffer-crc32": "^0.2.13",
     "cross-fetch": "^3.0.2",
     "es6-promisify": "^6.0.1",
     "generic-filehandle": "^2.0.0",

--- a/src/bamFile.ts
+++ b/src/bamFile.ts
@@ -345,7 +345,7 @@ export default class BamFile {
   }
   async _readChunk(chunk: Chunk, abortSignal?: AbortSignal) {
     let bufsize = chunk.fetchedSize()
-    if (!this.gzip) bufsize *= 3
+    if (!this.gzip) bufsize *= 10
     const res = await this.bam.read(Buffer.alloc(bufsize), 0, bufsize, chunk.minv.blockPosition, {
       signal: abortSignal,
     })

--- a/yarn.lock
+++ b/yarn.lock
@@ -931,6 +931,13 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/buffer-crc32@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@types/buffer-crc32/-/buffer-crc32-0.2.0.tgz#a4d94b1a4f01ea414268e9ef7576c7d32a1a14e4"
+  integrity sha512-6lBhJ55o2DKVCxTanyS6ohWRyebCcyivIK7pRHiwZuOYbUhivcByYBrvm2dc9f72LZP12mH5mGxUhG7JQ64lQg==
+  dependencies:
+    "@types/node" "*"
+
 "@types/eslint-visitor-keys@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
@@ -965,6 +972,11 @@
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.0.tgz#719551d2352d301ac8b81db732acb6bdc28dbdef"
   integrity sha512-1w52Nyx4Gq47uuu0EVcsHBxZFJgurQ+rTKS3qMHxR1GY2T8c2AJYd6vZoZ9q1rupaDjU0yT+Jc2XTyXkjeMA+Q==
+
+"@types/node@*":
+  version "12.12.21"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.21.tgz#aa44a6363291c7037111c47e4661ad210aded23f"
+  integrity sha512-8sRGhbpU+ck1n0PGAUgVrWrWdjSW2aqNeyC15W88GRsMpSwzv6RJGlLhE7s2RhVSOdyDmxbqlWSeThq4/7xqlA==
 
 "@types/node@^12.7.8":
   version "12.7.8"
@@ -1413,6 +1425,11 @@ bser@^2.0.0:
   integrity sha512-8zsjWrQkkBoLK6uxASk1nJ2SKv97ltiGDo6A3wA0/yRPz+CwmEyDo0hUrhIuukG2JHpAl3bvFIixw2/3Hi0DOg==
   dependencies:
     node-int64 "^0.4.0"
+
+buffer-crc32@^0.2.13:
+  version "0.2.13"
+  resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
+  integrity sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=
 
 buffer-from@^1.0.0:
   version "1.1.1"


### PR DESCRIPTION
This allows reading from servers like NCBI which are not returning gzip data properly, they're actually unzipping the gzip data before it hits our code

https://ftp.ncbi.nlm.nih.gov/giab/ftp/data/AshkenazimTrio/HG003_NA24149_father/PacBio_MtSinai_NIST/PacBio_minimap2_bam/HG003_PacBio_GRCh37.bam


http://ftp.ncbi.nlm.nih.gov/giab/ftp/data/AshkenazimTrio/HG002_NA24385_son/10XGenomics/NA24385_phased_possorted_bam.bam

I tried using `bufsize*3` as a heuristic factor but it had some feature fragments being returned so I increased it to `bufsize*10` and it looks ok but it is clearly a heuristic.