### PR TITLE
Improve bam performance

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,6 +12,7 @@
   ],
   "rules": {
     "no-underscore-dangle": 0,
+    "curly": "error",
     "@typescript-eslint/no-explicit-any": 0,
     "@typescript-eslint/explicit-function-return-type": 0,
     "semi": [

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
   - v8
-  - stable
+  - v12
 script:
   - yarn lint
   - yarn test --coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Adds a shortcut to stop parsing chunks after a record is detected to be outside the requested range while decoding
+
 <a name="1.0.35"></a>
 ## [1.0.35](https://github.com/GMOD/bam-js/compare/v1.0.34...v1.0.35) (2020-02-04)
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "test": "jest",
     "coverage": "npm test -- --coverage",
-    "lint": "eslint --report-unused-disable-directives --max-warnings 0 --ext .js,.ts src",
+    "lint": "eslint --report-unused-disable-directives --max-warnings 0 --ext .js,.ts src test",
     "clean": "rimraf dist",
     "prebuild": "npm run clean && npm run lint",
     "build:types": "tsc --emitDeclarationOnly",

--- a/src/bai.ts
+++ b/src/bai.ts
@@ -108,9 +108,13 @@ export default class BAI extends IndexFile {
     const range = start !== undefined
     const indexData = await this.parse()
     const seqIdx = indexData.indices[seqId]
-    if (!seqIdx) return []
+    if (!seqIdx) {
+      return []
+    }
     const { linearIndex = [], stats } = seqIdx
-    if (!linearIndex.length) return []
+    if (!linearIndex.length) {
+      return []
+    }
     const e = end !== undefined ? roundUp(end, v) : (linearIndex.length - 1) * v
     const s = start !== undefined ? roundDown(start, v) : 0
     let depths
@@ -144,21 +148,37 @@ export default class BAI extends IndexFile {
   reg2bins(beg: number, end: number) {
     const list = [0]
     end -= 1
-    for (let k = 1 + (beg >> 26); k <= 1 + (end >> 26); k += 1) list.push(k)
-    for (let k = 9 + (beg >> 23); k <= 9 + (end >> 23); k += 1) list.push(k)
-    for (let k = 73 + (beg >> 20); k <= 73 + (end >> 20); k += 1) list.push(k)
-    for (let k = 585 + (beg >> 17); k <= 585 + (end >> 17); k += 1) list.push(k)
-    for (let k = 4681 + (beg >> 14); k <= 4681 + (end >> 14); k += 1) list.push(k)
+    for (let k = 1 + (beg >> 26); k <= 1 + (end >> 26); k += 1) {
+      list.push(k)
+    }
+    for (let k = 9 + (beg >> 23); k <= 9 + (end >> 23); k += 1) {
+      list.push(k)
+    }
+    for (let k = 73 + (beg >> 20); k <= 73 + (end >> 20); k += 1) {
+      list.push(k)
+    }
+    for (let k = 585 + (beg >> 17); k <= 585 + (end >> 17); k += 1) {
+      list.push(k)
+    }
+    for (let k = 4681 + (beg >> 14); k <= 4681 + (end >> 14); k += 1) {
+      list.push(k)
+    }
     return list
   }
 
   async blocksForRange(refId: number, min: number, max: number) {
-    if (min < 0) min = 0
+    if (min < 0) {
+      min = 0
+    }
 
     const indexData = await this.parse()
-    if (!indexData) return []
+    if (!indexData) {
+      return []
+    }
     const ba = indexData.indices[refId]
-    if (!ba) return []
+    if (!ba) {
+      return []
+    }
 
     const overlappingBins = this.reg2bins(min, max) // List of bin #s that overlap min, max
     const chunks: Chunk[] = []
@@ -194,7 +214,9 @@ export default class BAI extends IndexFile {
     const mergedChunks: Chunk[] = []
     let lastChunk: Chunk | null = null
 
-    if (chunks.length === 0) return chunks
+    if (chunks.length === 0) {
+      return chunks
+    }
 
     chunks.sort(function(c0, c1) {
       const dif = c0.minv.blockPosition - c1.minv.blockPosition

--- a/src/bamFile.ts
+++ b/src/bamFile.ts
@@ -58,14 +58,14 @@ export default class BamFile {
     chunkSizeLimit,
     renameRefSeqs = n => n,
   }: {
-    bamFilehandle?: G
+    bamFilehandle?: GenericFilehandle
     bamPath?: string
     bamUrl?: string
     baiPath?: string
-    baiFilehandle?: G
+    baiFilehandle?: GenericFilehandle
     baiUrl?: string
     csiPath?: string
-    csiFilehandle?: G
+    csiFilehandle?: GenericFilehandle
     csiUrl?: string
     cacheSize?: number
     fetchSizeLimit?: number
@@ -136,7 +136,9 @@ export default class BamFile {
 
     const uncba = await unzip(buffer)
 
-    if (uncba.readInt32LE(0) !== BAM_MAGIC) throw new Error('Not a BAM file')
+    if (uncba.readInt32LE(0) !== BAM_MAGIC) {
+      throw new Error('Not a BAM file')
+    }
     const headLen = uncba.readInt32LE(4)
 
     this.header = uncba.toString('utf8', 8, 8 + headLen)
@@ -243,10 +245,11 @@ export default class BamFile {
     }
 
     const totalSize = chunks.map((s: Chunk) => s.fetchedSize()).reduce((a: number, b: number) => a + b, 0)
-    if (totalSize > this.fetchSizeLimit)
+    if (totalSize > this.fetchSizeLimit) {
       throw new Error(
         `data size of ${totalSize.toLocaleString()} bytes exceeded fetch size limit of ${this.fetchSizeLimit.toLocaleString()} bytes`,
       )
+    }
     yield* this._fetchChunkFeatures(chunks, chrId, min, max, opts)
   }
 
@@ -259,10 +262,10 @@ export default class BamFile {
       for (let i = 0; i < records.length; i += 1) {
         const feature = records[i]
         if (feature.seq_id() === chrId) {
-          if (feature.get('start') >= max)
+          if (feature.get('start') >= max) {
             // past end of range, can stop iterating
             break
-          else if (feature.get('end') >= min) {
+          } else if (feature.get('end') >= min) {
             // must be in range
             recs.push(feature)
           }
@@ -292,12 +295,16 @@ export default class BamFile {
         for (let i = 0; i < ret.length; i++) {
           const name = ret[i].name()
           const id = ret[i].id()
-          if (!readNames[name]) readNames[name] = 0
+          if (!readNames[name]) {
+            readNames[name] = 0
+          }
           readNames[name]++
           readIds[id] = 1
         }
         entries(readNames).forEach(([k, v]: [string, number]) => {
-          if (v === 1) unmatedPairs[k] = true
+          if (v === 1) {
+            unmatedPairs[k] = true
+          }
         })
       }),
     )
@@ -389,7 +396,7 @@ export default class BamFile {
       const blockSize = ba.readInt32LE(blockStart)
       const blockEnd = blockStart + 4 + blockSize - 1
 
-      for (pos = 0; blockStart + chunk.minv.dataPosition >= dpositions[pos]; pos++);
+      for (pos = 0; blockStart + chunk.minv.dataPosition >= dpositions[pos]; pos++) {}
 
       // only try to read the feature if we have all the bytes for it
       if (blockEnd < ba.length) {

--- a/src/chunk.ts
+++ b/src/chunk.ts
@@ -33,7 +33,9 @@ export default class Chunk {
   }
 
   fetchedSize() {
-    if (this._fetchedSize !== undefined) return this._fetchedSize
+    if (this._fetchedSize !== undefined) {
+      return this._fetchedSize
+    }
     return this.maxv.blockPosition + (1 << 16) - this.minv.blockPosition
   }
 }

--- a/src/csi.ts
+++ b/src/csi.ts
@@ -29,11 +29,17 @@ export default class CSI extends IndexFile {
   }
   async lineCount(refId: number): Promise<number> {
     const indexData = await this.parse()
-    if (!indexData) return -1
+    if (!indexData) {
+      return -1
+    }
     const idx = indexData.indices[refId]
-    if (!idx) return -1
+    if (!idx) {
+      return -1
+    }
     const { stats } = indexData.indices[refId]
-    if (stats) return stats.lineCount
+    if (stats) {
+      return stats.lineCount
+    }
     return -1
   }
   async indexCov() {
@@ -42,13 +48,17 @@ export default class CSI extends IndexFile {
   }
 
   parseAuxData(bytes: Buffer, offset: number, auxLength: number) {
-    if (auxLength < 30) return {}
+    if (auxLength < 30) {
+      return {}
+    }
 
     const data: { [key: string]: any } = {}
     data.formatFlags = bytes.readInt32LE(offset)
     data.coordinateType = data.formatFlags & 0x10000 ? 'zero-based-half-open' : '1-based-closed'
     data.format = ({ 0: 'generic', 1: 'SAM', 2: 'VCF' } as { [key: number]: string })[data.formatFlags & 0xf]
-    if (!data.format) throw new Error(`invalid Tabix preset format flags ${data.formatFlags}`)
+    if (!data.format) {
+      throw new Error(`invalid Tabix preset format flags ${data.formatFlags}`)
+    }
     data.columnNumbers = {
       ref: bytes.readInt32LE(offset + 4),
       start: bytes.readInt32LE(offset + 8),
@@ -158,12 +168,18 @@ export default class CSI extends IndexFile {
   }
 
   async blocksForRange(refId: number, beg: number, end: number, opts: Record<string, any> = {}): Promise<Chunk[]> {
-    if (beg < 0) beg = 0
+    if (beg < 0) {
+      beg = 0
+    }
 
     const indexData = await this.parse(opts.signal)
-    if (!indexData) return []
+    if (!indexData) {
+      return []
+    }
     const indexes = indexData.indices[refId]
-    if (!indexes) return []
+    if (!indexes) {
+      return []
+    }
 
     const { binIndex } = indexes
 
@@ -172,23 +188,30 @@ export default class CSI extends IndexFile {
     let l
     let numOffsets = 0
     for (let i = 0; i < bins.length; i += 1) {
-      if (binIndex[bins[i]]) numOffsets += binIndex[bins[i]].length
+      if (binIndex[bins[i]]) {
+        numOffsets += binIndex[bins[i]].length
+      }
     }
 
-    if (numOffsets === 0) return []
+    if (numOffsets === 0) {
+      return []
+    }
 
     let off = []
     numOffsets = 0
     for (let i = 0; i < bins.length; i += 1) {
       const chunks = binIndex[bins[i]]
-      if (chunks)
+      if (chunks) {
         for (let j = 0; j < chunks.length; j += 1) {
           off[numOffsets] = new Chunk(chunks[j].minv, chunks[j].maxv, chunks[j].bin)
           numOffsets += 1
         }
+      }
     }
 
-    if (!off.length) return []
+    if (!off.length) {
+      return []
+    }
 
     off = off.sort((a, b) => a.compareTo(b))
 
@@ -213,8 +236,9 @@ export default class CSI extends IndexFile {
     // merge adjacent blocks
     l = 0
     for (let i = 1; i < numOffsets; i += 1) {
-      if (off[l].maxv.blockPosition === off[i].minv.blockPosition) off[l].maxv = off[i].maxv
-      else {
+      if (off[l].maxv.blockPosition === off[i].minv.blockPosition) {
+        off[l].maxv = off[i].maxv
+      } else {
         l += 1
         off[l].minv = off[i].minv
         off[l].maxv = off[i].maxv
@@ -231,8 +255,12 @@ export default class CSI extends IndexFile {
    */
   reg2bins(beg: number, end: number) {
     beg -= 1 // < convert to 1-based closed
-    if (beg < 1) beg = 1
-    if (end > 2 ** 50) end = 2 ** 34 // 17 GiB ought to be enough for anybody
+    if (beg < 1) {
+      beg = 1
+    }
+    if (end > 2 ** 50) {
+      end = 2 ** 34
+    } // 17 GiB ought to be enough for anybody
     end -= 1
     let l = 0
     let t = 0
@@ -241,11 +269,14 @@ export default class CSI extends IndexFile {
     for (; l <= this.depth; s -= 3, t += lshift(1, l * 3), l += 1) {
       const b = t + rshift(beg, s)
       const e = t + rshift(end, s)
-      if (e - b + bins.length > this.maxBinNumber)
+      if (e - b + bins.length > this.maxBinNumber) {
         throw new Error(
           `query ${beg}-${end} is too large for current binning scheme (shift ${this.minShift}, depth ${this.depth}), try a smaller query or a coarser index binning scheme`,
         )
-      for (let i = b; i <= e; i += 1) bins.push(i)
+      }
+      for (let i = b; i <= e; i += 1) {
+        bins.push(i)
+      }
     }
     return bins
   }

--- a/src/indexFile.ts
+++ b/src/indexFile.ts
@@ -47,11 +47,12 @@ export default abstract class IndexFile {
   }
 
   async parse(abortSignal?: AbortSignal) {
-    if (!this._parseCache)
+    if (!this._parseCache) {
       this._parseCache = new AbortablePromiseCache({
         cache: new QuickLRU({ maxSize: 1 }),
         fill: (data: any, signal: AbortSignal) => this._parse(signal),
       })
+    }
     return this._parseCache.get('index', null, abortSignal)
   }
 

--- a/src/record.ts
+++ b/src/record.ts
@@ -77,8 +77,9 @@ export default class BamRecord {
       'supplementary_alignment',
     ]
 
-    if (!this.isSegmentUnmapped())
+    if (!this.isSegmentUnmapped()) {
       tags.push('start', 'end', 'strand', 'score', 'qual', 'MQ', 'CIGAR', 'length_on_ref', 'template_length')
+    }
     if (this.isPaired()) {
       tags.push(
         'multi_segment_all_correctly_aligned',
@@ -93,12 +94,16 @@ export default class BamRecord {
     tags = tags.concat(this._tagList || [])
 
     Object.keys(this.data).forEach(k => {
-      if (k[0] !== '_' && k !== 'multi_segment_all_aligned' && k !== 'next_seq_id') tags.push(k)
+      if (k[0] !== '_' && k !== 'multi_segment_all_aligned' && k !== 'next_seq_id') {
+        tags.push(k)
+      }
     })
 
     const seen: { [key: string]: boolean } = {}
     tags = tags.filter(t => {
-      if (t in this.data && this.data[t] === undefined) return false
+      if (t in this.data && this.data[t] === undefined) {
+        return false
+      }
 
       const lt = t.toLowerCase()
       const s = seen[lt]
@@ -139,7 +144,9 @@ export default class BamRecord {
   }
 
   qual() {
-    if (this.isSegmentUnmapped()) return undefined
+    if (this.isSegmentUnmapped()) {
+      return undefined
+    }
 
     const { byteArray } = this.bytes
     const p = this.bytes.start + 36 + this.get('_l_read_name') + this.get('_n_cigar_op') * 4 + this.get('_seq_bytes')
@@ -156,7 +163,9 @@ export default class BamRecord {
   }
 
   multi_segment_next_segment_strand() {
-    if (this.isMateUnmapped()) return undefined
+    if (this.isMateUnmapped()) {
+      return undefined
+    }
     return this.isMateReverseComplemented() ? -1 : 1
   }
 
@@ -177,7 +186,9 @@ export default class BamRecord {
     // if all of the tags have been parsed and we're still being
     // called, we already know that we have no such tag, because
     // it would already have been cached.
-    if (this._allTagsParsed) return undefined
+    if (this._allTagsParsed) {
+      return undefined
+    }
 
     const { byteArray } = this.bytes
     let p =
@@ -240,7 +251,9 @@ export default class BamRecord {
             p += 4
             for (let k = 0; k < limit; k++) {
               value += byteArray.readInt32LE(p)
-              if (k + 1 < limit) value += ','
+              if (k + 1 < limit) {
+                value += ','
+              }
               p += 4
             }
           }
@@ -249,7 +262,9 @@ export default class BamRecord {
             p += 4
             for (let k = 0; k < limit; k++) {
               value += byteArray.readInt16LE(p)
-              if (k + 1 < limit) value += ','
+              if (k + 1 < limit) {
+                value += ','
+              }
               p += 2
             }
           }
@@ -258,7 +273,9 @@ export default class BamRecord {
             p += 4
             for (let k = 0; k < limit; k++) {
               value += byteArray.readInt8(p)
-              if (k + 1 < limit) value += ','
+              if (k + 1 < limit) {
+                value += ','
+              }
               p += 1
             }
           }
@@ -267,7 +284,9 @@ export default class BamRecord {
             p += 4
             for (let k = 0; k < limit; k++) {
               value += byteArray.readFloatLE(p)
-              if (k + 1 < limit) value += ','
+              if (k + 1 < limit) {
+                value += ','
+              }
               p += 4
             }
           }
@@ -282,7 +301,9 @@ export default class BamRecord {
       this._tagOffset = p
 
       this._tagList.push(tag)
-      if (lcTag === tagName) return value
+      if (lcTag === tagName) {
+        return value
+      }
 
       this.data[lcTag] = value
     }
@@ -367,7 +388,9 @@ export default class BamRecord {
   }
 
   cigar() {
-    if (this.isSegmentUnmapped()) return undefined
+    if (this.isSegmentUnmapped()) {
+      return undefined
+    }
 
     const { byteArray, start } = this.bytes
     const numCigarOps = this.get('_n_cigar_op')
@@ -382,7 +405,9 @@ export default class BamRecord {
 
       // soft clip, hard clip, and insertion don't count toward
       // the length on the reference
-      if (op !== 'H' && op !== 'S' && op !== 'I') lref += lop
+      if (op !== 'H' && op !== 'S' && op !== 'I') {
+        lref += lop
+      }
 
       p += 4
     }
@@ -495,7 +520,9 @@ export default class BamRecord {
   toJSON() {
     const data: { [key: string]: any } = {}
     Object.keys(this).forEach(k => {
-      if (k.charAt(0) === '_' || k === 'bytes') return
+      if (k.charAt(0) === '_' || k === 'bytes') {
+        return
+      }
       //@ts-ignore
       data[k] = this[k]
     })

--- a/src/sam.ts
+++ b/src/sam.ts
@@ -7,7 +7,9 @@ export function parseHeaderText(text: string) {
       const [fieldTag, value] = f.split(':', 2)
       return { tag: fieldTag, value }
     })
-    if (tag) data.push({ tag: tag.substr(1), data: parsedFields })
+    if (tag) {
+      data.push({ tag: tag.substr(1), data: parsedFields })
+    }
   })
   return data
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -23,12 +23,15 @@ export function longToNumber(long: Long) {
  * @returns nothing
  */
 export function checkAbortSignal(signal?: AbortSignal) {
-  if (!signal) return
+  if (!signal) {
+    return
+  }
 
   if (signal.aborted) {
     // console.log('bam aborted!')
-    if (typeof DOMException !== 'undefined') throw new DOMException('aborted', 'AbortError')
-    else {
+    if (typeof DOMException !== 'undefined') {
+      throw new DOMException('aborted', 'AbortError')
+    } else {
       const e = new Error('aborted')
       // eslint-disable-next-line  @typescript-eslint/ban-ts-ignore
       //@ts-ignore

--- a/src/virtualOffset.ts
+++ b/src/virtualOffset.ts
@@ -17,15 +17,21 @@ export default class VirtualOffset {
   static min(...args: VirtualOffset[]) {
     let min
     let i = 0
-    for (; !min; i += 1) min = args[i]
+    for (; !min; i += 1) {
+      min = args[i]
+    }
     for (; i < args.length; i += 1) {
-      if (min.compareTo(args[i]) > 0) min = args[i]
+      if (min.compareTo(args[i]) > 0) {
+        min = args[i]
+      }
     }
     return min
   }
 }
 export function fromBytes(bytes: Buffer, offset = 0, bigendian = false) {
-  if (bigendian) throw new Error('big-endian virtual file offsets not implemented')
+  if (bigendian) {
+    throw new Error('big-endian virtual file offsets not implemented')
+  }
 
   return new VirtualOffset(
     bytes[offset + 7] * 0x10000000000 +

--- a/test/bai.test.js
+++ b/test/bai.test.js
@@ -522,7 +522,6 @@ xtest('large chunks', async () => {
   expect(ret1[0].fetchedSize()).toBe(10893136)
 })
 
-
 // use on any large long read data file
 xtest('speed test', async () => {
   const ti = new BamFile({

--- a/test/bai.test.js
+++ b/test/bai.test.js
@@ -516,11 +516,12 @@ xtest('large chunks', async () => {
     filehandle: new LocalFile(require.resolve('./data/out.marked.bai')),
   })
 
-  const ret = await ti.parse()
+  await ti.parse()
   //index 16 == 'chr17'
   const ret1 = await ti.blocksForRange(16, 41248671, 41337570)
   expect(ret1[0].fetchedSize()).toBe(10893136)
 })
+
 
 // use on any large long read data file
 xtest('speed test', async () => {

--- a/test/csi.test.js
+++ b/test/csi.test.js
@@ -13,7 +13,6 @@ class HalfAbortController {
   }
 }
 
-
 describe('bam header', () => {
   it('loads volvox-sorted.bam', async () => {
     const ti = new BamFile({
@@ -318,8 +317,6 @@ describe('trigger range out of bounds file', () => {
   })
 })
 
-
-
 // we cannot determine duplicates as unique because we require dehashing
 test('unique id for duplicate features', async () => {
   const ti = new BamFile({
@@ -400,7 +397,7 @@ xtest('large chunks', async () => {
     filehandle: new LocalFile(require.resolve('./data/out.marked.csi')),
   })
 
-  const ret = await ti.parse()
+  await ti.parse()
   //index 16 == 'chr17'
   const ret1 = await ti.blocksForRange(16, 41248671, 41337570)
   expect(ret1[0].fetchedSize()).toBe(10893136)


### PR DESCRIPTION
This creates a shortcut that stops parsing chunks after it is determined that a record is outside the requested range


