### PR TITLE
Yield thread time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
+- New param yieldThreadTime to constructor to yield while processing
+
 <a name="1.1.6"></a>
+
 ## [1.1.6](https://github.com/GMOD/bam-js/compare/v1.1.5...v1.1.6) (2021-02-20)
-
-
 
 - Add qualRaw function on records for getting raw qual score array instead of string
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ The BAM class constructor accepts arguments
 - fetchSizeLimit - total size of the number of chunks being fetched at once. default: ~50MB
 - chunkSizeLimit - size limit on any individual chunk. default: ~10MB
 - cacheSize - limit on number of chunks to cache. default: 50
+- yieldThreadTime - the interval at which the code yields to the main thread when it is parsing a lot of data. default: 100ms. Set to 0 to performed no yielding
 
 Note: filehandles implement the Filehandle interface from https://www.npmjs.com/package/generic-filehandle. This module offers the path and url arguments as convenience methods for supplying the LocalFile and RemoteFile
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@babel/runtime-corejs3": "^7.5.5",
     "@gmod/bgzf-filehandle": "^1.3.3",
-    "abortable-promise-cache": "^1.2.0",
+    "abortable-promise-cache": "^1.4.0",
     "buffer-crc32": "^0.2.13",
     "cross-fetch": "^3.0.2",
     "es6-promisify": "^6.0.1",

--- a/src/bamFile.ts
+++ b/src/bamFile.ts
@@ -50,7 +50,7 @@ export default class BamFile {
     cacheSize,
     fetchSizeLimit,
     chunkSizeLimit,
-    yieldThreadTime = 0,
+    yieldThreadTime = 100,
     renameRefSeqs = n => n,
   }: {
     bamFilehandle?: GenericFilehandle

--- a/yarn.lock
+++ b/yarn.lock
@@ -1194,10 +1194,10 @@ abab@^2.0.0:
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.3.tgz#623e2075e02eb2d3f2475e49f99c91846467907a"
   integrity sha512-tsFzPpcttalNjFBCFMqsKYQcWxxen1pgJR56by//QwvJc4/OUS3kPOOttx2tSIfjsylB0pYu7f5D3K1RCxUnUg==
 
-abortable-promise-cache@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/abortable-promise-cache/-/abortable-promise-cache-1.2.0.tgz#cb48bc5583654383d23709cf5d0d5b56d9c8146f"
-  integrity sha512-kKEN5e569SV8br+gqDwMmpglTD2wlJshaBfU97o+5OCYMUQx5terlWTfgb0a0uq1bvt82SrwzEium5gR0n2frQ==
+abortable-promise-cache@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/abortable-promise-cache/-/abortable-promise-cache-1.4.0.tgz#9c71ce279222790c66b0028255edcf5b6ebb8c3b"
+  integrity sha512-21Gtkd2bR9fgiomUMixnUwkV8m0kUsd3VZUXjz2scNLKv8j0esrmQgDj6LfDwUhlJidJvoFsmYX0snVFvE3j6g==
   dependencies:
     "@babel/runtime" "^7.0.0"
     abortcontroller-polyfill "^1.2.9"


### PR DESCRIPTION
This changes to making yielding the main thread an optional opt-in behavior

It can considerably speed things up to not yield, which is a benefit, and of course jbrowse 2 is on a webworker so doesnt need to really yield except for ping