### PR TITLE
Update to buffer-crc32 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,13 +41,12 @@
   "dependencies": {
     "@gmod/bgzf-filehandle": "^1.4.4",
     "abortable-promise-cache": "^1.5.0",
-    "buffer-crc32": "^0.2.13",
+    "buffer-crc32": "^1.0.0",
     "generic-filehandle": "^3.0.0",
     "long": "^4.0.0",
     "quick-lru": "^4.0.0"
   },
   "devDependencies": {
-    "@types/buffer-crc32": "^0.2.2",
     "@types/jest": "^29.5.1",
     "@types/long": "^4.0.0",
     "@types/node": "^18.16.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1136,10 +1136,10 @@ bser@2.1.1:
   dependencies:
     node-int64 "^0.4.0"
 
-buffer-crc32@^0.2.13:
-  version "0.2.13"
-  resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
-  integrity sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==
+buffer-crc32@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-1.0.0.tgz#a10993b9055081d55304bd9feb4a072de179f405"
+  integrity sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==
 
 buffer-from@^1.0.0:
   version "1.1.2"


### PR DESCRIPTION
Hey! We've spent some effort lately to clean up the buffer-crc32 library and push the 1.0.0 release forward. Thought you may want to upgrade! Should be a drop-in replacement, and TS types are bundled now too