### PR TITLE
Experimental: remove chunk cache

### DIFF
--- a/src/bamFile.ts
+++ b/src/bamFile.ts
@@ -231,7 +231,18 @@ export default class BamFile {
     const feats = [] as BAMFeature[][]
     let done = false
 
+    console.log(chunks.length)
+    let i = 0
     for (const chunk of chunks) {
+      console.log(
+        i++,
+        chunk.bin,
+        chunk.maxv,
+        chunk.minv,
+        chrId,
+        min.toLocaleString(),
+        max.toLocaleString(),
+      )
       const { data, cpositions, dpositions } = await this._readChunk({
         chunk,
         opts,
@@ -258,6 +269,7 @@ export default class BamFile {
       feats.push(recs)
       yield recs
       if (done) {
+        console.log({ done })
         break
       }
     }

--- a/src/bamFile.ts
+++ b/src/bamFile.ts
@@ -1,8 +1,6 @@
-import AbortablePromiseCache from '@gmod/abortable-promise-cache'
 import { unzip, unzipChunkSlice } from '@gmod/bgzf-filehandle'
 import crc32 from 'crc/calculators/crc32'
 import { LocalFile, RemoteFile } from 'generic-filehandle2'
-import QuickLRU from 'quick-lru'
 
 import BAI from './bai'
 import Chunk from './chunk'
@@ -24,10 +22,6 @@ import type { GenericFilehandle } from 'generic-filehandle2'
 export const BAM_MAGIC = 21840194
 
 const blockLen = 1 << 16
-interface Args {
-  chunk: Chunk
-  opts: BaseOpts
-}
 
 export default class BamFile {
   public renameRefSeq: (a: string) => string
@@ -39,20 +33,6 @@ export default class BamFile {
   public index?: BAI | CSI
   public htsget = false
   public headerP?: ReturnType<BamFile['getHeaderPre']>
-
-  private featureCache = new AbortablePromiseCache<Args, BAMFeature[]>({
-    cache: new QuickLRU({
-      maxSize: 50,
-    }),
-    fill: async (args: Args, signal) => {
-      const { chunk, opts } = args
-      const { data, cpositions, dpositions } = await this._readChunk({
-        chunk,
-        opts: { ...opts, signal },
-      })
-      return this.readBamFeatures(data, cpositions, dpositions, chunk)
-    },
-  })
 
   constructor({
     bamFilehandle,
@@ -252,12 +232,16 @@ export default class BamFile {
     let done = false
 
     for (const chunk of chunks) {
-      const records = await this.featureCache.get(
-        chunk.toString(),
-        { chunk, opts },
-        opts.signal,
+      const { data, cpositions, dpositions } = await this._readChunk({
+        chunk,
+        opts,
+      })
+      const records = await this.readBamFeatures(
+        data,
+        cpositions,
+        dpositions,
+        chunk,
       )
-
       const recs = [] as BAMFeature[]
       for (const feature of records) {
         if (feature.ref_id === chrId) {


### PR DESCRIPTION
This is an experimental attempt at removing caching from the bam-js library. The cache size is basically uncontrolled and can result in essentially a memory leak. Additionally, in normal jbrowse style usage of the bam-js library, there are many cache misses, and this makes the benefit of the cache somewhat marginal

A solution should be made that either

a) just removes cache
b) improves cache hit rate, and controls cache size

this PR is (a) but is just for experimental purposes right now

here is a picture that shows a pattern of requests from a single page load


![Screenshot 2025-03-15 at 2 40 18 PM(3)](https://github.com/user-attachments/assets/48eac49d-463e-4923-b207-8b6f23eeaae6)


the columns are individual requests to the bam-js library. note that these trigger parsing of many overlapping regions  particularly for long reads, of the bam file itself, even though the requests themselves, e.g. for the static blocks, are non-overlapping.



